### PR TITLE
[RFC] Fix bugs in cache directory creation

### DIFF
--- a/src/DiagramGenerator/Diagram/Board.php
+++ b/src/DiagramGenerator/Diagram/Board.php
@@ -91,7 +91,7 @@ class Board
         $this->cacheDir = $this->rootCacheDir . '/' . $this->cacheDirName;
 
         if (!file_exists($this->cacheDir)) {
-            @mkdir($this->cacheDir);
+            mkdir($this->cacheDir, 0777);
         }
 
         $this->image  = new \Imagick();
@@ -303,7 +303,7 @@ class Board
         }
 
         if (!file_exists($this->cacheDir . '/' . $pieceThemeName . '/' . $cellSize)) {
-            @mkdir($this->cacheDir . '/' . $pieceThemeName . '/' . $cellSize, 0777, true);
+            mkdir($this->cacheDir . '/' . $pieceThemeName . '/' . $cellSize, 0777, true);
         }
 
         $pieceThemeUrl = str_replace('__PIECE_THEME__', $pieceThemeName, $this->pieceThemeUrl);
@@ -330,7 +330,7 @@ class Board
         }
 
         if (!file_exists($this->cacheDir . '/board/' . $this->getBoardTexture())) {
-            @mkdir($this->cacheDir . '/board/' . $this->getBoardTexture(), 0777, true);
+            mkdir($this->cacheDir . '/board/' . $this->getBoardTexture(), 0777, true);
         }
 
         $boardTextureUrl = str_replace('__BOARD_TEXTURE__', $this->getBoardTexture(), $this->boardTextureUrl);

--- a/src/DiagramGenerator/Generator.php
+++ b/src/DiagramGenerator/Generator.php
@@ -9,7 +9,7 @@ use DiagramGenerator\Config\Theme;
 use DiagramGenerator\Diagram\Board;
 use DiagramGenerator\Exception\UnsupportedConfigException;
 use Symfony\Component\Validator\Validation;
-use Symfony\Component\Validator\Validator;
+use Symfony\Component\Validator\Validator\RecursiveValidator as Validator;
 
 /**
  * Generator class

--- a/tests/DiagramGenerator/Tests/GeneratorTest.php
+++ b/tests/DiagramGenerator/Tests/GeneratorTest.php
@@ -31,7 +31,7 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->validatorMock = $this->getMockBuilder('Symfony\Component\Validator\Validator')
+        $this->validatorMock = $this->getMockBuilder('Symfony\Component\Validator\Validator\RecursiveValidator')
             ->disableOriginalConstructor()
             ->getMock();
 


### PR DESCRIPTION
## Background
The caching directory is owned by a different user depending on what environment it's created in.  This, coupled with too-tight permissions of the cache root caused the cache code not to function under the `test` environment.

The cause was hidden by `@` suppression on the `mkdir` commands, which should be unnecessary since the directory is checked for existence beforehand.

Finally, the binary output occurred because although `curl` complains of the redirect file handle being bogus, it's not fatal and the `curl_exec` command then pulls the image and dumps it to the default location, `stdout`.

/cc @lackovic10 @marcosdsanchez 