### PR TITLE
Enable warning suppression on mkdir

### DIFF
--- a/src/DiagramGenerator/Diagram/Board.php
+++ b/src/DiagramGenerator/Diagram/Board.php
@@ -88,11 +88,7 @@ class Board
         $boardTextureUrlExploded = explode('.', $boardTextureUrl);
         $this->imagesExtension = $boardTextureUrlExploded[count($boardTextureUrlExploded) - 1];
 
-        $this->cacheDir = $this->rootCacheDir . '/' . $this->cacheDirName;
-
-        if (!file_exists($this->cacheDir)) {
-            mkdir($this->cacheDir, 0777);
-        }
+        @mkdir($this->rootCacheDir . '/' . $this->cacheDirName, 0777);
 
         $this->image  = new \Imagick();
         $this->fen = Fen::createFromString($this->config->getFen());
@@ -302,9 +298,7 @@ class Board
             return $pieceCachedPath;
         }
 
-        if (!file_exists($this->cacheDir . '/' . $pieceThemeName . '/' . $cellSize)) {
-            mkdir($this->cacheDir . '/' . $pieceThemeName . '/' . $cellSize, 0777, true);
-        }
+        @mkdir($this->cacheDir . '/' . $pieceThemeName . '/' . $cellSize, 0777, true);
 
         $pieceThemeUrl = str_replace('__PIECE_THEME__', $pieceThemeName, $this->pieceThemeUrl);
         $pieceThemeUrl = str_replace('__SIZE__', $cellSize, $pieceThemeUrl);
@@ -329,9 +323,7 @@ class Board
             return $boardCachedPath;
         }
 
-        if (!file_exists($this->cacheDir . '/board/' . $this->getBoardTexture())) {
-            mkdir($this->cacheDir . '/board/' . $this->getBoardTexture(), 0777, true);
-        }
+        @mkdir($this->cacheDir . '/board/' . $this->getBoardTexture(), 0777, true);
 
         $boardTextureUrl = str_replace('__BOARD_TEXTURE__', $this->getBoardTexture(), $this->boardTextureUrl);
         $boardTextureUrl = str_replace('__SIZE__', $this->getCellSize(), $boardTextureUrl);


### PR DESCRIPTION
## Background
There's no way to make the combination of `file_exists` and `mkdir` into an atomic operation, so a race condition exists such that another process will create the directory in between one process's calls to `file_exists` and `mkdir`.  This results in an error such as [this](https://rollbar.com/ChessCom-2/Chess.com---Production-Beta/items/5087/?item_page=0#instances)

## Solution
The best solution to create the directory if it is not there is to just rely on `mkdir` and then suppress any warnings if the directory already exists.