### PR TITLE
Ensure symfony 2.5+, 2.4- compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ framework:
     validation: { enable_annotations: true }
 ```
 
+### Testing
+
+Clone the library, run php composer.phar install, and run php vendor/bin/phpunit to run the unit tests.
+
 ### Bonus
 
 `Fen` object is a convenient way to work with fen strings and represents the board as a list of all pieces, each one is an instance of `DiagramGenerator\Fen\Piece` object, has color, row and column properties. It can be developed according to our future needs

--- a/src/DiagramGenerator/Diagram/Board.php
+++ b/src/DiagramGenerator/Diagram/Board.php
@@ -7,6 +7,7 @@ use DiagramGenerator\Generator;
 use DiagramGenerator\Fen;
 use DiagramGenerator\Fen\Piece;
 use ImagickDraw;
+use RuntimeException;
 
 /**
  * Class responsible for drawing the board
@@ -87,6 +88,8 @@ class Board
 
         $boardTextureUrlExploded = explode('.', $boardTextureUrl);
         $this->imagesExtension = $boardTextureUrlExploded[count($boardTextureUrlExploded) - 1];
+
+        $this->cacheDir = $this->rootCacheDir . '/' . $this->cacheDirName;
 
         @mkdir($this->rootCacheDir . '/' . $this->cacheDirName, 0777);
 
@@ -377,6 +380,11 @@ class Board
     {
         $ch = curl_init($remoteImageUrl);
         $destinationFileHandle = fopen($cachedFilePath, 'wb');
+
+        if (!$destinationFileHandle) {
+            throw new RuntimeException(sprintf('Could not open file: %s', $cachedFilePath));
+        }
+
         curl_setopt($ch, CURLOPT_FILE, $destinationFileHandle);
         curl_setopt($ch, CURLOPT_HEADER, 0);
         curl_exec($ch);

--- a/src/DiagramGenerator/Generator.php
+++ b/src/DiagramGenerator/Generator.php
@@ -9,7 +9,7 @@ use DiagramGenerator\Config\Theme;
 use DiagramGenerator\Diagram\Board;
 use DiagramGenerator\Exception\UnsupportedConfigException;
 use Symfony\Component\Validator\Validation;
-use Symfony\Component\Validator\Validator;
+use Symfony\Component\Validator\ValidatorInterface;
 
 /**
  * Generator class
@@ -17,7 +17,7 @@ use Symfony\Component\Validator\Validator;
  */
 class Generator
 {
-    /** @var \Symfony\Component\Validator\Validator */
+    /** @var \Symfony\Component\Validator\ValidatorInterface */
     protected $validator;
 
     /** @var array $boardTextures */
@@ -26,7 +26,7 @@ class Generator
     /** @var array $pieceThemes */
     protected $pieceThemes = array();
 
-    public function __construct(Validator $validator)
+    public function __construct(ValidatorInterface $validator)
     {
         $this->validator = $validator;
     }

--- a/tests/DiagramGenerator/Tests/GeneratorTest.php
+++ b/tests/DiagramGenerator/Tests/GeneratorTest.php
@@ -11,7 +11,7 @@ use DiagramGenerator\Generator;
  */
 class GeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var \Symfony\Component\Validator\Validator $validator */
+    /** @var \Symfony\Component\Validator\ValidatorInterface $validator */
     protected $validatorMock;
 
     /** @var \DiagramGenerator\Generator $generator */
@@ -31,7 +31,7 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->validatorMock = $this->getMockBuilder('Symfony\Component\Validator\Validator')
+        $this->validatorMock = $this->getMockBuilder('Symfony\Component\Validator\ValidatorInterface')
             ->disableOriginalConstructor()
             ->getMock();
 


### PR DESCRIPTION
Use the `ValidatorInterface` instead of the `Validator` class.
Fix a bug which occurred because the `Board::$cacheDir` was accidentally deleted.

@kalifg tagging you because of the [bug fix](https://github.com/ChessCom/DiagramGenerator/commit/5f1b6a3a904e52b6d3a7b2325a1b57cc7c323551)
please check the other commit, too, if you can.