### PR TITLE
Avoid collisions when writing cache files from stream

### DIFF
--- a/src/DiagramGenerator/Diagram/Board.php
+++ b/src/DiagramGenerator/Diagram/Board.php
@@ -380,11 +380,12 @@ class Board
      */
     protected function cacheImage($remoteImageUrl, $cachedFilePath)
     {
+        $cachedFilePathTmp = $cachedFilePath . uniqid('', true);
         $ch = curl_init($remoteImageUrl);
-        $destinationFileHandle = fopen($cachedFilePath, 'wb');
+        $destinationFileHandle = fopen($cachedFilePathTmp, 'wb');
 
         if (!$destinationFileHandle) {
-            throw new RuntimeException(sprintf('Could not open file: %s', $cachedFilePath));
+            throw new RuntimeException(sprintf('Could not open temporary file: %s', $cachedFilePathTmp));
         }
 
         curl_setopt($ch, CURLOPT_FILE, $destinationFileHandle);
@@ -392,6 +393,8 @@ class Board
         curl_exec($ch);
         curl_close($ch);
         fclose($destinationFileHandle);
+
+        rename($cachedFilePathTmp, $cachedFilePath);
     }
 
     /**


### PR DESCRIPTION
This is an idea for https://chesscom.atlassian.net/browse/CV-6561

Simultaneous downloads to the same path could create corrupted records. Instead, stream to a unique temporary file path and then move to the final path so only completed downloads are in that location.

I'm not entirely sure how to test this. Ideas?

/cc: @lackovic10 