### PR TITLE
Add the board texture image format to the configuration

### DIFF
--- a/src/DiagramGenerator/Config.php
+++ b/src/DiagramGenerator/Config.php
@@ -64,15 +64,6 @@ class Config
     protected $pieceIndex;
 
     /**
-     * @Type("string")
-     * @StringOrInteger(min=0, max=3)
-     * @SerializedName("board")
-     * @var integer
-     */
-    // [lackovic10]: these are board texture folder names from the image url
-    protected $boardIndex;
-
-    /**
      * @Exclude()
      * @var \DiagramGenerator\Config\Texture
      */
@@ -344,30 +335,6 @@ class Config
     public function setDark($dark)
     {
         $this->dark = $dark;
-
-        return $this;
-    }
-
-    /**
-     * Gets the value of boardIndex.
-     *
-     * @return integer
-     */
-    public function getBoardIndex()
-    {
-        return $this->boardIndex;
-    }
-
-    /**
-     * Sets the value of the $boardIndex field. Keeping old values (0-3) for backwards compatibility
-     *
-     * @param string|int $boardIndex
-     *
-     * @return Config
-     */
-    public function setBoardIndex($boardIndex)
-    {
-        $this->boardIndex = $boardIndex;
 
         return $this;
     }

--- a/src/DiagramGenerator/Config/Texture.php
+++ b/src/DiagramGenerator/Config/Texture.php
@@ -3,6 +3,7 @@
 namespace DiagramGenerator\Config;
 
 use JMS\Serializer\Annotation\Type;
+use InvalidArgumentException;
 
 /**
  * Class to keep texture config
@@ -11,34 +12,78 @@ use JMS\Serializer\Annotation\Type;
  */
 class Texture
 {
-    /**
-     * Boards filename
-     * @Type("string")
-     * @var string
-     */
-    protected $board;
+    const IMAGE_FORMAT_PNG = 'png';
+    const IMAGE_FORMAT_JPG = 'jpg';
+
+    /** @var string $name */
+    protected $name;
+
+    /** @var string $imageUrlFolderName */
+    protected $imageUrlFolderName;
+
+    /** @var string $imageFormat */
+    protected $imageFormat;
+
+    /** @var string $highlightSquaresColor The default highlight squares color for the board texture */
+    protected $highlightSquaresColor;
 
     /**
-     * Gets the Boards filename.
-     *
-     * @return string
+     * @param string      $name
+     * @param string      $imageUrlFolderName
+     * @param string      $imageFormat
+     * @param string|null $highlightSquaresColor
      */
-    public function getBoard()
+    public function __construct($name, $imageUrlFolderName, $imageFormat, $highlightSquaresColor = null)
     {
-        return $this->board;
+        if (!in_array($imageFormat, array(self::IMAGE_FORMAT_PNG, self::IMAGE_FORMAT_JPG))) {
+            throw new InvalidArgumentException(sprintf('Invalid image format: %s', $imageFormat));
+        }
+
+        $this->name = $name;
+        $this->imageUrlFolderName = $imageUrlFolderName;
+        $this->imageFormat = $imageFormat;
+        $this->highlightSquaresColor = $highlightSquaresColor;
     }
 
     /**
-     * Sets the Boards filename.
-     *
-     * @param string $board the board
-     *
-     * @return self
+     * @return string
      */
-    public function setBoard($board)
+    public function getName()
     {
-        $this->board = $board;
+        return $this->name;
+    }
 
-        return $this;
+    /**
+     * @return string
+     */
+    public function getImageUrlFolderName()
+    {
+        return $this->imageUrlFolderName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getImageFormat()
+    {
+        return $this->imageFormat;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHighlightSquaresColor()
+    {
+        return $this->highlightSquaresColor;
+    }
+
+    /**
+     * @param DiagramGenerator\Config\Texture $texture
+     *
+     * @return boolean
+     */
+    public function is(Texture $texture)
+    {
+        return $this->name === $texture->getName() && $this->imageUrlFolderName === $texture->getImageUrlFolderName();
     }
 }

--- a/src/DiagramGenerator/Generator.php
+++ b/src/DiagramGenerator/Generator.php
@@ -51,8 +51,11 @@ class Generator
             throw new InvalidConfigException($errors->__toString());
         }
 
+        if ($config->getTexture()) {
+            $this->validateBoardTexture($config->getTexture());
+        }
+
         $this->setConfigSize($config);
-        $this->setConfigBoardTexture($config);
         $this->setConfigPieceTheme($config);
 
         $config->setHighlightSquares(
@@ -115,20 +118,21 @@ class Generator
     }
 
     /**
-     * Set the config board texture
+     * @param DiagramGenerator\Config\Texture $textureForValidation
      *
-     * @param Config $config
+     * @throws InvalidArgumentException
      */
-    protected function setConfigBoardTexture(Config $config)
+    protected function validateBoardTexture(Texture $textureForValidation)
     {
-        $boardTexture = $config->getBoardIndex();
-
-        if ($boardTexture && !in_array($boardTexture, $this->boardTextures)) {
-            throw new \InvalidArgumentException(sprintf('Board texture %s does not exist', $boardTexture));
+        foreach ($this->boardTextures as $boardTexture) {
+            if ($boardTexture->is($textureForValidation)) {
+                return;
+            }
         }
 
-        $texture = new Texture();
-        $config->setTexture($texture->setBoard($boardTexture));
+        throw new \InvalidArgumentException(
+            sprintf('Board texture %s does not exist', $textureForValidation->getName())
+        );
     }
 
     /**

--- a/tests/DiagramGenerator/Tests/GeneratorTest.php
+++ b/tests/DiagramGenerator/Tests/GeneratorTest.php
@@ -4,6 +4,7 @@ namespace DiagramGenerator\Tests;
 
 use Symfony\Component\Validator\ConstraintViolationList;
 use DiagramGenerator\Config;
+use DiagramGenerator\Config\Texture;
 use DiagramGenerator\Generator;
 
 /**
@@ -106,7 +107,7 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $this->config->setSizeIndex('200px')
             ->setPieceIndex('3d_chesskid')
-            ->setBoardIndex('non-existent');
+            ->setTexture(new Texture('non-existent', 'non-existent', 'png'));
 
         $this->assertValidatorMockWithNoErrors($this->config);
 


### PR DESCRIPTION
Our board textures [have been optimized](https://github.com/ChessCom/chess/pull/8201) by @rangogligoric, and now we have some that stay as `png` while the others are converted to `jpg`.
This PR adds the required configuration option of defining the board texture file extension. The `Texture` class is updated with new fields. The board texture validation has been updated in the `Generator` class. The class expects the configuration object to contain the `Texture` object, instead of the `boardIndex` simple value which was removed from the `Config` class.

 - [x] update the class `Texture`, add new fields  `name`, `imageUrlFolderName`, `imageFormat`, `highlightSquaresColor`
 - [x] rm `Config::$boardIndex`
 - [x] rm `Board:$imagesExtension`
 - [x] update board texture validation in the `Generator` class

