### PR TITLE
Add jpg compression

### DIFF
--- a/src/DiagramGenerator/Diagram.php
+++ b/src/DiagramGenerator/Diagram.php
@@ -7,6 +7,7 @@ use DiagramGenerator\Config\ThemeColor;
 use DiagramGenerator\Diagram\Board;
 use DiagramGenerator\Diagram\Caption;
 use DiagramGenerator\Diagram\Coordinate;
+use DiagramGenerator\Config\Texture;
 
 /**
  * Class which represents diagram image
@@ -14,6 +15,7 @@ use DiagramGenerator\Diagram\Coordinate;
  */
 class Diagram
 {
+    const COMPRESSION_QUALITY_JPG = 80;
     /**
      * @var \DiagramGenerator\Config
      */
@@ -150,7 +152,10 @@ class Diagram
             $this->image = $this->image->appendImages(true);
         }
 
-        $this->image->setImageFormat('png');
+        $this->image->setImageFormat($this->board->getImageFormat());
+        if ($this->image->getImageFormat() === Texture::IMAGE_FORMAT_JPG) {
+            $this->image->setImageCompressionQuality(self::COMPRESSION_QUALITY_JPG);
+        }
 
         return $this;
     }
@@ -189,7 +194,7 @@ class Diagram
 
         // Add text
         $coordinate->getImage()->annotateImage($draw, 0, 0, 0, $text);
-        $coordinate->getImage()->setImageFormat('png');
+        $coordinate->getImage()->setImageFormat($this->board->getImageFormat());
 
         return $coordinate;
     }

--- a/src/DiagramGenerator/Diagram/Board.php
+++ b/src/DiagramGenerator/Diagram/Board.php
@@ -9,6 +9,7 @@ use DiagramGenerator\Generator;
 use DiagramGenerator\Fen;
 use DiagramGenerator\Fen\Piece;
 use ImagickDraw;
+use Imagick;
 use RuntimeException;
 
 /**
@@ -209,7 +210,7 @@ class Board
      */
     public function draw()
     {
-        $this->image->setImageFormat(Texture::IMAGE_FORMAT_PNG);
+        $this->image->setImageFormat($this->getImageFormat());
 
         return $this;
     }
@@ -226,6 +227,20 @@ class Board
     public function getPaddingTop()
     {
         return $this->paddingTop;
+    }
+
+    /**
+     * Get the board's image format. The whole dynboard image format is dependent on the board image format.
+     *
+     * @return string
+     */
+    public function getImageFormat()
+    {
+        if ($this->config->getTexture()) {
+            return $this->config->getTexture()->getImageFormat();
+        }
+
+        return Texture::IMAGE_FORMAT_PNG;
     }
 
     /**


### PR DESCRIPTION
Add jpg compression for jpg dynboards. The dynboard image format is determined by the board image format. The jpg compression quality is set to **80%**

/cc @rangogligoric @BiviaBen 