### PR TITLE
CV-29995 Transparent dynboard

### DIFF
--- a/src/DiagramGenerator/Image/Image.php
+++ b/src/DiagramGenerator/Image/Image.php
@@ -182,6 +182,8 @@ class Image
         );
 
         if ($backgroundTexture) {
+            $this->addTransparencyIfNeeded($board, $backgroundTexture->getCore());
+
             imagecopyresampled(
                 $board, $backgroundTexture->getCore(),
                 0, 0, 0, 0,
@@ -289,5 +291,19 @@ class Image
         }
 
         return $coordinates;
+    }
+
+    protected function addTransparencyIfNeeded($board, $textureCore)
+    {
+        $rgba = imagecolorat($textureCore, 1, 1);
+        $alpha = ($rgba & 0x7F000000) >> 24;
+        $isTransparent = $alpha > 0;
+
+        if ($isTransparent) {
+            imagealphablending($board, false);
+            imagesavealpha($board, true);
+            $color = imagecolorallocatealpha($board, 255, 255, 255, 127);
+            imagefill($board, 0, 0, $color);
+        }
     }
 }


### PR DESCRIPTION
Jira: https://chesscom.atlassian.net/browse/CV-29995

Transparency was removed from one texture, when we migrated to GD. This fixes it.

Fix compiled from few snippets found online :)