### PR TITLE
CV-27227 Parallel piece downloading

### DIFF
--- a/src/DiagramGenerator/Fen.php
+++ b/src/DiagramGenerator/Fen.php
@@ -65,9 +65,9 @@ class Fen
      */
     public static function getPieceByKey($key)
     {
-        $color = 'white';
+        $color = Piece::WHITE;
         if (preg_match('/[A-Z]/', $key) === 0) {
-            $color = 'black';
+            $color = Piece::BLACK;
         }
 
         switch (strtolower($key)) {

--- a/src/DiagramGenerator/Fen/Piece.php
+++ b/src/DiagramGenerator/Fen/Piece.php
@@ -138,4 +138,22 @@ abstract class Piece
     {
         return substr($this->getColor(), 0, 1).$this->getKey();
     }
+
+    /**
+     * @return Piece[]
+     */
+    public static function generateAllPieces()
+    {
+        $white = [];
+        $black = [];
+
+        $pieceClasses = [Bishop::class, King::class, Knight::class, Pawn::class, Queen::class, Rook::class];
+
+        foreach ($pieceClasses as $piece) {
+            $white[] = new $piece(self::WHITE);
+            $black[] = new $piece(self::BLACK);
+        }
+
+        return array_merge($white, $black);
+    }
 }

--- a/src/DiagramGenerator/Image/Storage.php
+++ b/src/DiagramGenerator/Image/Storage.php
@@ -124,19 +124,7 @@ class Storage
         try {
             $image = ImageManagerStatic::make($pieceCachedPath);
         } catch (NotReadableException $exception) {
-            @mkdir($this->cacheDirectory.'/'.$pieceThemeName.'/'.$cellSize, 0777, true);
-
-            $pieceThemeUrl = strtr(
-                $this->pieceThemeUrl,
-                [
-                    '__PIECE_THEME__' => $pieceThemeName,
-                    '__SIZE__' => $cellSize,
-                    '__PIECE__' => $piece->getShortName(),
-                ]
-            );
-            $pieceThemeUrl .= '.'.Texture::IMAGE_FORMAT_PNG;
-
-            $this->cacheImage($pieceThemeUrl, $pieceCachedPath);
+            $this->downloadPieceImages($config);
             $image = ImageManagerStatic::make($pieceCachedPath);
         }
 
@@ -189,5 +177,60 @@ class Storage
         fclose($destinationFileHandle);
 
         rename($cachedFilePathTmp, $cachedFilePath);
+    }
+
+    private function downloadPieceImages(Config $config)
+    {
+        $pieces = Piece::generateAllPieces();
+
+        $pieceThemeName = $config->getTheme()->getName();
+        $cellSize = $config->getSize()->getCell();
+        @mkdir($this->cacheDirectory.'/'.$pieceThemeName.'/'.$cellSize, 0777, true);
+
+        $handles = [];
+        $fileHandles = [];
+        $multiHandle = curl_multi_init();
+
+        $pieceThemeName = $config->getTheme()->getName();
+        $cellSize = $config->getSize()->getCell();
+
+        foreach ($pieces as $piece) {
+            $pieceUrl = $this->generatePieceUrl($piece, $config);
+            $handles[$piece->getShortName()] = curl_init($pieceUrl);
+            $fileUrl = $this->getCachedPieceFilePath($pieceThemeName, $cellSize, $piece->getShortName());
+            $fileHandles[$piece->getShortName()] = fopen($fileUrl, 'wb');
+        }
+
+        foreach($handles as $key => $handle) {
+            curl_setopt($handle, CURLOPT_FILE, $fileHandles[$key]);
+            curl_setopt($handle, CURLOPT_HEADER, 0);
+
+            curl_multi_add_handle($multiHandle, $handle);
+        }
+
+        do {
+            curl_multi_exec($multiHandle, $running);
+            curl_multi_select($multiHandle);
+        } while ($running > 0);
+
+        curl_multi_close($multiHandle);
+    }
+
+    private function generatePieceUrl(Piece $piece, Config $config)
+    {
+        $pieceThemeName = $config->getTheme()->getName();
+        $cellSize = $config->getSize()->getCell();
+
+        $pieceThemeUrl = strtr(
+            $this->pieceThemeUrl,
+            [
+                '__PIECE_THEME__' => $pieceThemeName,
+                '__SIZE__' => $cellSize,
+                '__PIECE__' => $piece->getShortName(),
+            ]
+        );
+        $pieceThemeUrl .= '.'.Texture::IMAGE_FORMAT_PNG;
+
+        return $pieceThemeUrl;
     }
 }


### PR DESCRIPTION
Jira: https://chesscom.atlassian.net/browse/CV-27227

We used to download piece images one at a time, which meant up to 16 successive http requests, to get each image. Changed that to use `curl_multi_exec`, so now all pieces are downloaded in parallel, for the theme and size. 

Code changes are fairly simple. Parallel curl execution is explained [here](http://php.net/manual/en/function.curl-multi-exec.php).